### PR TITLE
adjusted css to fix various code text appearance probs [TRAIN-459]

### DIFF
--- a/boundless_rtd/static/css/boundless.css
+++ b/boundless_rtd/static/css/boundless.css
@@ -109,13 +109,30 @@ div[class^="highlight"] pre
 	color: #333333;
 }
 
+/* format TOC entries */
+.rst-content .toctree-wrapper
+{
+	  font-family: "Proxima Nova", "Montserrat", "Helvetica", Arial, sans-serif;
+    /*font-size: 14px;*/
+    font-weight: bold;
+}
+
+/* format captions */
+.rst-content .caption-text
+{
+	  font-family: "Proxima Nova", "Montserrat", "Helvetica", Arial, sans-serif;
+    font-size: 14px;
+    font-style: italic;
+}
+
+
 a.reference.external::after
 {
 	font-family: 'FontAwesome';
 	content: " \f08e";
 }
 
-/** override theme.css layout */
+/* override theme.css layout */
 .wy-nav-content
 {
 	max-width: unset;
@@ -133,4 +150,25 @@ a.reference.external::after
 .rst-versions a {
     color: white;
     text-decoration: none;
+}
+
+/* Override wy-nav colors to match company branding */
+.wy-side-nav-search, .wy-side-nav-search img, .wy-nav .wy-menu-vertical header, .wy-nav-top, .wy-nav-top img
+{
+	  background-color: #28728d;
+}
+
+/* center figures and captions */
+.rst-content div.figure { text-align: center; }
+
+/* make menuselection have same style as guilabel */
+.rst-content .menuselection
+{
+	  border: 1px solid #7fbbe3;
+	  background: #e7f2fa;
+	  font-size: 80%;
+	  font-weight: 700;
+	  border-radius: 4px;
+	  padding: 2.4px 6px;
+	  margin: auto 2px;
 }

--- a/boundless_rtd/static/css/boundless.css
+++ b/boundless_rtd/static/css/boundless.css
@@ -88,6 +88,12 @@ footer .footer-aside
 	padding-top: 6px;
 }
 
+/* make tables scroll on mobile devices */
+.wy-table-responsive
+{
+    -webkit-overflow-scrolling: touch;
+}
+
 /*grid background for code blocks*/
 pre
 {
@@ -96,7 +102,7 @@ pre
 	background-color: #f8f8f8;
 }
 
-div[class^="highlight"] pre
+.rst-content div[class^="highlight"] pre
 {
 	white-space: pre;
 	margin: 0;

--- a/boundless_rtd/static/css/boundless.css
+++ b/boundless_rtd/static/css/boundless.css
@@ -55,6 +55,15 @@ footer .logo-link
 	margin-right: 5px;
 }
 
+/** Set appearance for inline code format **/
+/*.rst-content code.literal { color: Black; }*/
+.rst-content code.literal
+{
+    color: Black;
+    font-family: 'Source Code Pro', Consolas, "Courier New", monospace;
+    font-size: 100%;
+}
+
 footer .logo-link .boundless-logo
 {
 	background: url("../img/boundless-logo-32.png") no-repeat;
@@ -77,6 +86,14 @@ footer .footer-aside
 	display: inline-block;
 	float: right;
 	padding-top: 6px;
+}
+
+/*grid background for code blocks*/
+pre
+{
+    background: linear-gradient(-90deg, rgba(0, 0, 0, .01) 1px, transparent 1px), linear-gradient(rgba(0, 0, 0, .01) 1px, transparent 1px), linear-gradient(-90deg, rgba(0, 0, 0, .01) 1px, transparent 1px), linear-gradient(rgba(0, 0, 0, .01) 1px, transparent 1px), linear-gradient(transparent 3px, transparent 3px, transparent 78px, transparent 78px), linear-gradient(-90deg, transparent 1px, transparent 1px), linear-gradient(-90deg, transparent 3px, transparent 3px, transparent 78px, transparent 78px), linear-gradient(transparent 1px, transparent 1px), transparent;
+	background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px, 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+	background-color: #f8f8f8;
 }
 
 div[class^="highlight"] pre

--- a/boundless_rtd/static/css/boundless.css
+++ b/boundless_rtd/static/css/boundless.css
@@ -61,7 +61,7 @@ footer .logo-link
 {
     color: Black;
     font-family: 'Source Code Pro', Consolas, "Courier New", monospace;
-    font-size: 100%;
+    font-size: 90%;
 }
 
 footer .logo-link .boundless-logo

--- a/boundless_rtd/theme.conf
+++ b/boundless_rtd/theme.conf
@@ -1,6 +1,7 @@
 [theme]
 inherit = sphinx_rtd_theme
 stylesheet = css/boundless.css
+pygments_style = trac
 
 [options]
 display_connect = false

--- a/learning_rtd_theme/theme.conf
+++ b/learning_rtd_theme/theme.conf
@@ -9,3 +9,5 @@ sticky_navigation = True
 theme_display_connect = True
 display_version = True
 is_community = False
+prev_next_buttons_location = none # ignored
+display_connect = none # ignore

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -15,3 +15,5 @@ logo_only =
 display_version = True
 prev_next_buttons_location = bottom
 style_external_links = False
+
+display_connect = False # ignore

--- a/test/src/conf.py
+++ b/test/src/conf.py
@@ -75,7 +75,7 @@ if tags.has('scormintro'):
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
[TRAIN-459](https://jira.boundlessgeo.com/browse/TRAIN-459) progress:

Here are a list of glitches between `learning_rtd` and `boundless_rtd` themes:

# Branding

Priority:

* [x] when in narrow mode the top of the page shows document tile and menu for navigation, the background-color here [rgb(41, 128, 185)] should be [rgb(40, 114, 141);]

Desired:

* [ ] Firefox is not picking up Proxima Nova (Safari does no the same machine)

# Consistency

Top priority:

* [x] code examples have a yellow background and very small text (should be Source Code Pro with a grid background)
* [x] landing page toc divisions are represented as captions, using `Roboto Slab`, should be Proxima Nova
* [x] menubar is not shown with a background (like guilabel)
* [x] code examples are more colorful, should try and match learning_rtd here

Desired:

* [x] screen shots should be centred
* [x] figure captions should be smaller and gray
* [x] the colors used for notes
* [x] colors used for notes should shift to blue
* [x] guilabel has a colored background

# Initial Font Awesome Load Madness

Initial page load has problems (clicking the home icon causes the page to redraw and it now works):

* [ ] when first opened font awesome symbols (like "home" icon at top of nav bar) do not display
* [ ] dynamic sizing does not work (makes sidebar big not content)

update: The original `rtd` theme also appears to have this problem! We are going to hope this is not a problem in the LMS. Confirmed it is a not a problem for LMS. See [TRAIN-475]*https://jira.boundlessgeo.com/browse/TRAIN-475).
